### PR TITLE
Dir common remove

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: reuseme
 Title: Collections of Utility Functions to Work Across Projects
-Version: 0.0.2.9002
+Version: 0.0.2.9003
 Authors@R: 
     person("Olivier", "Roy", , "olivierroy71@hotmail.com", role = c("aut", "cre"))
 Description: Allows you to browse current projects, rename files safely,

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@
 * In `proj_outline()`, `proj` has been renamed `path`, but still accepts a project name,
 that will passed on to `proj_list()`
 
+* Removed `dir_common` from `file_outline()` (#35)
+
 ## Fixes
 
 * `file_outline()` now recognize `describe()` test calls. 

--- a/R/markup.R
+++ b/R/markup.R
@@ -57,9 +57,10 @@ link_local_gh_issue <- function(x, repo_home) {
     x
   )
 }
-find_pkg_org_repo <- function(dir_common = NULL, file = NULL) {
+find_pkg_org_repo <- function(file = NULL) {
   rlang::local_interactive(FALSE)
   withr::local_options("usethis.quiet" = TRUE)
+  dir_common <- get_dir_common_outline(file)
   if (!is.null(dir_common)) {
     pkg_path <- tryCatch(
       rprojroot::find_package_root_file(path = dir_common),

--- a/R/outline.R
+++ b/R/outline.R
@@ -51,7 +51,6 @@
 #' @param dir_tree If `TRUE`, will print the [fs::dir_tree()] or non-R files in
 #'   the directory
 #' @param recent_only Show outline for recent files
-#' @param dir_common (Do not use it)
 #' @inheritParams fs::dir_ls
 #' @returns A `outline_report` object that contains the information. Inherits
 #' `tbl_df`.
@@ -84,8 +83,7 @@ file_outline <- function(path = active_rs_doc(),
                          pattern = NULL,
                          alpha = FALSE,
                          print_todo = TRUE,
-                         recent_only = FALSE,
-                         dir_common = NULL) {
+                         recent_only = FALSE) {
   # To contribute to this function, take a look at .github/CONTRIBUTING
   check_string(pattern, allow_null = TRUE)
 
@@ -115,7 +113,7 @@ file_outline <- function(path = active_rs_doc(),
     }
 
     # if (rstudioapi::rstudio)
-    dir_common <- get_dir_common_outline(dir_common, path)
+    dir_common <- get_dir_common_outline(NULL, path)
 
     path <- stringr::str_sort(path)
     file_content <- rlang::set_names(path)
@@ -194,8 +192,7 @@ file_outline <- function(path = active_rs_doc(),
   )
   # Create hyperlink in console
   file_sections <- construct_outline_link(
-    file_sections1,
-    dir_common
+    file_sections1
   )
 
   file_sections$recent_only <- recent_only
@@ -239,7 +236,7 @@ proj_outline <- function(path = active_rs_proj(), pattern = NULL, dir_tree = FAL
 #' @export
 dir_outline <- function(path = ".", pattern = NULL, dir_tree = FALSE, alpha = FALSE, recent_only = FALSE, recurse = FALSE) {
   dir <- fs::path_real(path)
-  file_exts <- c("R", "qmd", "Rmd", "md", "Rmarkdown")
+  file_exts <- c("R", "RProfile", "qmd", "Rmd", "md", "Rmarkdown")
   file_exts_regex <- paste0("*.", file_exts, "$", collapse = "|")
 
   file_list_to_outline <- fs::dir_ls(
@@ -268,7 +265,7 @@ dir_outline <- function(path = ".", pattern = NULL, dir_tree = FALSE, alpha = FA
       invert = TRUE
     )
   }
-  file_outline(path = file_list_to_outline, pattern = pattern, dir_common = dir, alpha = alpha, recent_only = recent_only)
+  file_outline(path = file_list_to_outline, pattern = pattern, alpha = alpha, recent_only = recent_only)
 }
 
 exclude_example_files <- function(path) {
@@ -599,7 +596,8 @@ define_important_element <- function(.data) {
   )
 }
 
-construct_outline_link <- function(.data, dir_common) {
+construct_outline_link <- function(.data) {
+  dir_common <- get_dir_common_outline(NULL, path = unique(.data$file))
   is_saved_doc <- !any(.data$file == "unsaved-doc.R")
   is_active_doc <- length(unique(.data$file)) == 1L
   rs_avail_file_link <- is_rstudio("2023.09.0.375") # better handling after

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ bench::mark(
 #> # A tibble: 1 × 6
 #>   expression                     min   median `itr/sec` mem_alloc `gc/sec`
 #>   <bch:expr>                <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
-#> 1 outline <- proj_outline()    481ms    491ms      2.04    22.6MB     4.08
+#> 1 outline <- proj_outline()    560ms    560ms      1.79    22.7MB     3.57
 ```
 
 <details>

--- a/man/outline.Rd
+++ b/man/outline.Rd
@@ -12,8 +12,7 @@ file_outline(
   pattern = NULL,
   alpha = FALSE,
   print_todo = TRUE,
-  recent_only = FALSE,
-  dir_common = NULL
+  recent_only = FALSE
 )
 
 proj_outline(
@@ -47,8 +46,6 @@ The print method will show the document title for context. Previously \code{rege
 print a less verbose output with sections.}
 
 \item{recent_only}{Show outline for recent files}
-
-\item{dir_common}{(Do not use it)}
 
 \item{dir_tree}{If \code{TRUE}, will print the \code{\link[fs:dir_tree]{fs::dir_tree()}} or non-R files in
 the directory}


### PR DESCRIPTION
I only need `dir_common` when trying to find if the current repo has a BugReports field (in `find_pkg_org_repo()`

I need it for choosing which part of the path I will display. (1 file vs many files vs unsaved)