### PR TITLE
Move link creation inside `print.outline_report()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,8 @@ that will passed on to `proj_list()`
 
 * Removed `dir_common` from `file_outline()` (#35)
 
+* `file_outline()` result is now a simpler data frame. The cli links are now created in the print method. (which makes more sense for truncation)
+
 ## Fixes
 
 * Improved regex in `link_gh_issue()`.

--- a/R/outline-criteria.R
+++ b/R/outline-criteria.R
@@ -93,7 +93,7 @@ o_is_generic_test <- function(x) {
 # Returns table or plot titles.
 o_is_tab_plot_title <- function(x) {
   generic_title_regex <- paste(
-    "Foo|test|Title|TITLE|Subtitle|[eE]xample|x\\.x\\.",
+    "Foo|test|Title|TITLE|Subtitle|[eE]xample|x\\.x\\.|Header|hi there",
     "man_get_image_tab|table's|list\\(|bla\"|\", \"|use_.+\\(",
     sep = "|"
   )

--- a/R/outline.R
+++ b/R/outline.R
@@ -257,7 +257,8 @@ dir_outline <- function(path = ".", pattern = NULL, dir_tree = FALSE, alpha = FA
     regexp_exclude <- paste(
       "vignettes/test/", # test vignettes
       "LICENSE.md", # avoid indexing this.
-      "tests/(performance-monitor|gt-examples/|testthat/(dummy_|exclusions-test/|scope-|assets|_outline|testTestWithFailure|testTest/|test-parallel/|test-list-reporter/|examples/))", # example files in usethis, pkgdown, reuseme, devtools, etc.
+      "cran-comments.md",
+      "tests/(performance-monitor|gt-examples/|testthat/(dummy_|exclusions-test/|scope-|assets|_outline|testTestWithFailure|testTest/|test-parallel/|test-list-reporter/|serialize_tests/|line_breaks_and_other/|indentation_multiple/|public-api/|rmd/|examples/))", # example files in usethis, pkgdown, reuseme, devtools, etc.
       "inst/((rmarkdown/)?templates/|example-file/|examples/rmd/|tutorials/)", # license templates in usethis
       "revdep/", # likely don't need to outline revdep/, use dir_outline() to find something in revdep/
       "themes/hugo-theme-console/", # protect blogdown
@@ -285,7 +286,7 @@ exclude_example_files <- function(path) {
     "vignettes/test/", # test vignettes
     "LICENSE.md", # avoid indexing this.
     "cran-comments.md",
-    "tests/(performance-monitor|gt-examples/|testthat/(dummy_|exclusions-test/|scope-|assets|_outline|testTestWithFailure|testTest/|test-parallel/|test-list-reporter/|examples/))", # example files in usethis, pkgdown, reuseme, devtools, etc.
+    "tests/(performance-monitor|gt-examples/|testthat/(dummy_|exclusions-test/|scope-|assets|_outline|testTestWithFailure|testTest/|test-parallel/|test-list-reporter/|serialize_tests/|line_breaks_and_other/|indentation_multiple/|public-api/|rmd/|examples/))", # example files in usethis, pkgdown, reuseme, devtools, etc.
     "inst/((rmarkdown/)?templates/|example-file/|examples/rmd/|tutorials/)", # license templates in usethis
     "revdep/", # likely don't need to outline revdep/, use dir_outline() to find something in revdep/
     "themes/hugo-theme-console/", # protect blogdown

--- a/R/outline.R
+++ b/R/outline.R
@@ -361,6 +361,8 @@ print.outline_report <- function(x, ...) {
     cli::cli_abort(c("Expected each file to be listed once."), .internal = TRUE)
   }
   # At the moment, especially `active_rs_doc()`, we are relying on path inconsistencies by RStudio.
+  # TODO since April 2024, cli links work almost out of the box in VScode? microsoft/vscode#176812
+  # doesn't work when paths are created with cli::style_hyperlink, but maybe could use a different condition to show them as is.
   in_vscode <- FALSE # to do create it. # Sys.getenv("TERM_PROGRAM") == "vscode" when in vscode!
   if (in_vscode) {
     which_detect <- stringr::str_which(tolower(summary_links_files$file_hl), "file://\\~|file://c\\:", negate = TRUE)

--- a/R/outline.R
+++ b/R/outline.R
@@ -314,6 +314,13 @@ print.outline_report <- function(x, ...) {
     cli::cli_inform("Empty {.help [outline](reuseme::file_outline)}.")
     return(invisible(x))
   }
+  file_sections <- dplyr::as_tibble(x)
+  recent_only <- x$recent_only[1]
+  # add links and truncate elements
+  file_sections$outline_el[!is.na(file_sections$outline_el)] <-
+    escape_markup(file_sections$outline_el[!is.na(file_sections$outline_el)])
+  file_sections <- create_outline_links_and_truncate_content(file_sections)
+
   custom_styling <- c(
     # 500 is the max path length.
     # green todo
@@ -322,8 +329,7 @@ print.outline_report <- function(x, ...) {
     # Workaround r-lib/cli#693
     "\\[([[:alpha:]\\s]+)\\]\\s" = "{cli::bg_white(cli::col_black('\\1'))} "
   )
-  file_sections <- dplyr::as_tibble(x)
-  recent_only <- x$recent_only[1]
+
   file_sections$link_rs_api <- stringr::str_replace_all(file_sections$link_rs_api, custom_styling)
 
   if (anyDuplicated(stats::na.omit(file_sections$outline_el)) > 0L) {
@@ -412,13 +418,13 @@ print.outline_report <- function(x, ...) {
     if (recent_only) {
       if (i %in% is_recently_modified) {
         purrr::walk(dat[[i]], \(y) {
-          y <- escape_markup(y[!is.na(y)])
+          y <- y[!is.na(y)]
           if (length(y)) cat(cli::format_inline(y), sep = "\n")
         })
       }
     } else {
       purrr::walk(dat[[i]], \(y) {
-        y <- escape_markup(y[!is.na(y)])
+        y <- y[!is.na(y)]
         if (length(y)) cat(cli::format_inline(y), sep = "\n")
       })
     }

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ bench::mark(
 #> # A tibble: 1 × 6
 #>   expression                     min   median `itr/sec` mem_alloc `gc/sec`
 #>   <bch:expr>                <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
-#> 1 outline <- proj_outline()    717ms    717ms      1.40    22.3MB     4.19
+#> 1 outline <- proj_outline()    504ms    504ms      1.98    21.7MB     5.95
 ```
 
 <details>
@@ -227,6 +227,7 @@ outline
 #> `i` `file_outline()`
 #> `i` File outline
 #> `i` Print method
+#> `i` TODO since April 2024, cli links work almost out of the box in VScode? microsoft/vscode#176812 (<https://github.com/microsoft/vscode/issues/176812>)
 #> `i` Step: tweak outline look as they show
 #> `i` TODO reanable cli info
 #> `i` TODO Improve performance with vctrs tidyverse/dplyr#6806 (<https://github.com/tidyverse/dplyr/issues/6806>)
@@ -358,7 +359,8 @@ outline
 #> `i` Side effects are what's intended in interactive sessions
 #> 
 #> ── `tests/testthat/test-escape-inline-markup.R`
-#> `i` TODO could probably be {. } works?
+#> `i` TODO could . stay as is?
+#> `i` escape_markup() doesn't error for edge cases
 #> 
 #> ── `tests/testthat/test-markup.R`
 #> `i` link_gh_issue() + markup_href() work

--- a/tests/testthat/test-escape-inline-markup.R
+++ b/tests/testthat/test-escape-inline-markup.R
@@ -1,4 +1,4 @@
-test_that("escape_markup() works", {
+test_that("escape_markup() works with {", {
   expect_equal(escape_markup(c("gt", "y {")), c("gt", "y {{"))
   expect_equal(escape_markup(c("gt", "y {", "{gt}")), c("gt", "y {{", "{{gt}}"))
   expect_equal(escape_markup("{gt}"), "{{gt}}")
@@ -8,7 +8,7 @@ test_that("escape_markup() works", {
   expect_equal(escape_markup("This `}` and `{`"), "This `}}` and `{{`")
   expect_equal(escape_markup("This `{` and `}`"), "This `{{` and `}}`")
 
-  # TODO could probably be {{. }} works?
+  # TODO could {{. }} stay as is?
   expect_equal(escape_markup("{. } works"), ". works")
   input <- "multi problems {{gt}} to {gt} to {.file gt} to {.file {gt}}"
   exp_str <- "multi problems {{gt}} to {{gt}} to {.file gt} to {.file {.url gt}}"


### PR DESCRIPTION
Progress towards 
https://github.com/olivroy/reuseme/issues/28#issuecomment-2155364765

Performance gain!

Next step is to reshape the `file_outline()` to be:

| file | line | col | outline | type | content |
|--------|--------|--------|--------|--------|------|
| file | int | int | extracted outline element| "fn"/"todo"/"fixme"/"title"/"h1", "h2", etc.| original unmodified line content | 